### PR TITLE
EnsureIndexes robustness

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -31,6 +31,6 @@ $revision = "{0:D4}" -f [convert]::ToInt32($revision, 10)
 
 exec { & dotnet build }
 
-#exec { & dotnet test .\test\unit\unittests.csproj -c Release }
+exec { & dotnet test .\test\unit\unittests.csproj -c Release }
 
 exec { & dotnet pack .\src\rapidcore.mongo.csproj -c Release -o ..\artifacts --include-source }

--- a/rapidcore.mongo.sln
+++ b/rapidcore.mongo.sln
@@ -9,6 +9,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{91683FE2-6
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "functionaltests", "test\functional\functionaltests.csproj", "{76979851-7B58-4EB8-BE1B-B2FAB4D131CB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "unittests", "test\unit\unittests.csproj", "{6249341E-B470-462E-89E9-CE76EFAB88AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,8 +48,21 @@ Global
 		{76979851-7B58-4EB8-BE1B-B2FAB4D131CB}.Release|x64.Build.0 = Release|x64
 		{76979851-7B58-4EB8-BE1B-B2FAB4D131CB}.Release|x86.ActiveCfg = Release|x86
 		{76979851-7B58-4EB8-BE1B-B2FAB4D131CB}.Release|x86.Build.0 = Release|x86
+		{6249341E-B470-462E-89E9-CE76EFAB88AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6249341E-B470-462E-89E9-CE76EFAB88AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6249341E-B470-462E-89E9-CE76EFAB88AD}.Debug|x64.ActiveCfg = Debug|x64
+		{6249341E-B470-462E-89E9-CE76EFAB88AD}.Debug|x64.Build.0 = Debug|x64
+		{6249341E-B470-462E-89E9-CE76EFAB88AD}.Debug|x86.ActiveCfg = Debug|x86
+		{6249341E-B470-462E-89E9-CE76EFAB88AD}.Debug|x86.Build.0 = Debug|x86
+		{6249341E-B470-462E-89E9-CE76EFAB88AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6249341E-B470-462E-89E9-CE76EFAB88AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6249341E-B470-462E-89E9-CE76EFAB88AD}.Release|x64.ActiveCfg = Release|x64
+		{6249341E-B470-462E-89E9-CE76EFAB88AD}.Release|x64.Build.0 = Release|x64
+		{6249341E-B470-462E-89E9-CE76EFAB88AD}.Release|x86.ActiveCfg = Release|x86
+		{6249341E-B470-462E-89E9-CE76EFAB88AD}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{76979851-7B58-4EB8-BE1B-B2FAB4D131CB} = {91683FE2-6739-437A-8BD9-76BDD333FD33}
+		{6249341E-B470-462E-89E9-CE76EFAB88AD} = {91683FE2-6739-437A-8BD9-76BDD333FD33}
 	EndGlobalSection
 EndGlobal

--- a/src/Internal/IndexFromTypeExtensions.cs
+++ b/src/Internal/IndexFromTypeExtensions.cs
@@ -28,6 +28,11 @@ namespace RapidCore.Mongo.Internal
 
         private static void GetIndexDefinitionsWorker(TypeInfo type, IndexDefinitionCollection indexes, string fieldPrefix)
         {
+            if (fieldPrefix.Split('.').Count() > 20)
+            {
+                throw new InvalidOperationException($"Tree is too deep - could be a recursion. Current 'path' is {fieldPrefix}");
+            }
+
             var definitions = new Dictionary<string, IndexDefinition>();
 
             type

--- a/src/MongoManager.cs
+++ b/src/MongoManager.cs
@@ -21,32 +21,42 @@ namespace RapidCore.Mongo
 
             foreach (var type in types)
             {
-                type.GetIndexDefinitions().ToList().ForEach(index =>
-                {
-                    // make the following call:
-                    // lowLevelDb.GetCollection<TDocument>("collectionName").Indexes.CreateOne(index.GetKeySpec(), index.GetOptions())
-
-                    var genericDocType = new Type[] { index.DocumentType };
-
-                    var mongoCollection = lowLevelDb
-                        .GetType()
-                        .GetMethodRecursively("GetCollection", typeof(string), typeof(MongoCollectionSettings))
-                        .MakeGenericMethod(genericDocType)
-                        .Invoke(lowLevelDb, new object[] { index.Collection, null });
-
-                    var collectionIndexes = mongoCollection.InvokeGetterRecursively("Indexes");
-
-                    collectionIndexes
-                        .GetType()
-                        .GetMethodRecursively(
-                            "CreateOne",
-                            typeof(IndexKeysDefinition<>).MakeGenericType(genericDocType),
-                            typeof(CreateIndexOptions),
-                            typeof(CancellationToken)
-                        )
-                        .Invoke(collectionIndexes, new object[] { index.GetKeySpec(), index.GetOptions(), null });
-                });
+                EnsureIndexes(lowLevelDb, type);
             }
+        }
+
+        public void EnsureIndexes(IMongoDatabase lowLevelDb, Type type)
+        {
+            EnsureIndexes(lowLevelDb, type.GetTypeInfo());
+        }
+
+        public void EnsureIndexes(IMongoDatabase lowLevelDb, TypeInfo type)
+        {
+            type.GetIndexDefinitions().ToList().ForEach(index =>
+            {
+                // make the following call:
+                // lowLevelDb.GetCollection<TDocument>("collectionName").Indexes.CreateOne(index.GetKeySpec(), index.GetOptions())
+
+                var genericDocType = new Type[] { index.DocumentType };
+
+                var mongoCollection = lowLevelDb
+                    .GetType()
+                    .GetMethodRecursively("GetCollection", typeof(string), typeof(MongoCollectionSettings))
+                    .MakeGenericMethod(genericDocType)
+                    .Invoke(lowLevelDb, new object[] { index.Collection, null });
+
+                var collectionIndexes = mongoCollection.InvokeGetterRecursively("Indexes");
+
+                collectionIndexes
+                    .GetType()
+                    .GetMethodRecursively(
+                        "CreateOne",
+                        typeof(IndexKeysDefinition<>).MakeGenericType(genericDocType),
+                        typeof(CreateIndexOptions),
+                        typeof(CancellationToken)
+                    )
+                    .Invoke(collectionIndexes, new object[] { index.GetKeySpec(), index.GetOptions(), null });
+            });
         }
     }
 }

--- a/test/functional/MongoManager_EnsureIndexes_Tests.cs
+++ b/test/functional/MongoManager_EnsureIndexes_Tests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using MongoDB.Bson;
@@ -62,6 +63,14 @@ namespace RapidCore.Mongo.FunctionalTests
             Assert.Equal(new BsonDocument().Add("Nested.OnNested", 1), actual["Nested.OnNested_1"].GetElement("key").Value);
         }
 
+        [Fact]
+        public void DetectsRecursionAndStops()
+        {
+            var actual = Assert.Throws<InvalidOperationException>(() => CreateAndGetIndexes<RecursiveParent>());
+
+            Assert.Equal("Tree is too deep - could be a recursion. Current 'path' is Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.", actual.Message);
+        }
+
         #region Create and get indexes
         private IDictionary<string, BsonDocument> CreateAndGetIndexes<TDocument>()
         {
@@ -71,8 +80,7 @@ namespace RapidCore.Mongo.FunctionalTests
 
             manager.EnsureIndexes(
                 GetDb(),
-                typeof(TDocument).GetTypeInfo().Assembly,
-                typeof(TDocument).GetTypeInfo().Namespace
+                typeof(TDocument)
             );
 
             return GetIndexes<TDocument>(collectionName);
@@ -148,6 +156,19 @@ namespace RapidCore.Mongo.FunctionalTests
         {
             [Index]
             public string OnNested { get; set; }
+        }
+        #endregion
+
+        #region Recursive
+        [Entity]
+        private class RecursiveParent
+        {
+            public RecursiveChild Child { get; set; }
+        }
+
+        private class RecursiveChild
+        {
+            public RecursiveParent Parent { get; set; }
         }
         #endregion
     }

--- a/test/functional/MongoManager_EnsureIndexes_Tests.cs
+++ b/test/functional/MongoManager_EnsureIndexes_Tests.cs
@@ -63,14 +63,6 @@ namespace RapidCore.Mongo.FunctionalTests
             Assert.Equal(new BsonDocument().Add("Nested.OnNested", 1), actual["Nested.OnNested_1"].GetElement("key").Value);
         }
 
-        [Fact]
-        public void DetectsRecursionAndStops()
-        {
-            var actual = Assert.Throws<InvalidOperationException>(() => CreateAndGetIndexes<RecursiveParent>());
-
-            Assert.Equal("Tree is too deep - could be a recursion. Current 'path' is Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.", actual.Message);
-        }
-
         #region Create and get indexes
         private IDictionary<string, BsonDocument> CreateAndGetIndexes<TDocument>()
         {
@@ -156,19 +148,6 @@ namespace RapidCore.Mongo.FunctionalTests
         {
             [Index]
             public string OnNested { get; set; }
-        }
-        #endregion
-
-        #region Recursive
-        [Entity]
-        private class RecursiveParent
-        {
-            public RecursiveChild Child { get; set; }
-        }
-
-        private class RecursiveChild
-        {
-            public RecursiveParent Parent { get; set; }
         }
         #endregion
     }

--- a/test/unit/Internal/IndexFromTypeExtensionsTests.cs
+++ b/test/unit/Internal/IndexFromTypeExtensionsTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Reflection;
+using RapidCore.Mongo.Internal;
+using Xunit;
+
+namespace RapidCore.Mongo.UnitTests.Internal
+{
+    public class IndexFromTypeExtensionsTests
+    {
+        [Fact]
+        public void DetectsRecursionAndStops()
+        {
+            var actual = Assert.Throws<InvalidOperationException>(() => typeof(RecursiveParent).GetTypeInfo().GetIndexDefinitions());
+
+            Assert.Equal("Tree is too deep - could be a recursion. Current 'path' is Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.", actual.Message);
+        }
+        
+        #region Recursive
+        [Entity]
+        private class RecursiveParent
+        {
+            public RecursiveChild Child { get; set; }
+        }
+
+        private class RecursiveChild
+        {
+            public RecursiveParent Parent { get; set; }
+        }
+        #endregion
+    }
+}

--- a/test/unit/Internal/IndexFromTypeExtensionsTests.cs
+++ b/test/unit/Internal/IndexFromTypeExtensionsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using MongoDB.Bson;
 using RapidCore.Mongo.Internal;
 using Xunit;
 
@@ -14,6 +15,16 @@ namespace RapidCore.Mongo.UnitTests.Internal
 
             Assert.Equal("Tree is too deep - could be a recursion. Current 'path' is Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.Child.Parent.", actual.Message);
         }
+
+        [Fact]
+        public void DealsWithTheInsanityOfObjectId()
+        {
+            var actual = typeof(WithObjectId).GetTypeInfo().GetIndexDefinitions();
+
+            Assert.Equal(1, actual.Count);
+            Assert.Equal(1, actual[0].Keys.Count);
+            Assert.Equal("ThisIsOk", actual[0].Keys[0].Name);
+        }
         
         #region Recursive
         [Entity]
@@ -25,6 +36,17 @@ namespace RapidCore.Mongo.UnitTests.Internal
         private class RecursiveChild
         {
             public RecursiveParent Parent { get; set; }
+        }
+        #endregion
+
+        #region Mongo ObjectId
+        [Entity]
+        private class WithObjectId
+        {
+            public ObjectId Id { get; set; }
+
+            [Index]
+            public string ThisIsOk { get; set; }
         }
         #endregion
     }

--- a/test/unit/unittests.csproj
+++ b/test/unit/unittests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <RootNamespace>RapidCore.Mongo.UnitTests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.*" />
+    <PackageReference Include="MongoDB.Bson" Version="2.4.*" />
+    <PackageReference Include="MongoDB.Driver" Version="2.4.*" />
+    <PackageReference Include="MongoDB.Driver.Core" Version="2.4.*" />
+    <PackageReference Include="xunit" Version="2.2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\rapidcore.mongo.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds handling of static properties.
Adds handling of System.* types.
Adds recursion detection.
Adds drop-and-retry in cases where the index already exists, but has been changed in the code.