### PR TITLE
Add MongoDbConnection.GetAsync

### DIFF
--- a/src/MongoDbConnection.cs
+++ b/src/MongoDbConnection.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using MongoDB.Driver;
@@ -54,6 +55,28 @@ namespace RapidCore.Mongo
             return this.mongoDb
                 .GetCollection<TDocument>(collectionName)
                 .DeleteManyAsync(filter);
+        }
+
+        /// <summary>
+        /// UNSTABLE API!!
+        /// 
+        /// Get all documents that match the given filter.
+        /// </summary>
+        /// <param name="collectionName">The collection to work on</param>
+        /// <param name="filter">Filter for finding documents</param>
+        /// <param name="limit">Optional limit on how many documents you want</param>
+        public virtual async Task<IList<TDocument>> GetAsync<TDocument>(string collectionName, Expression<Func<TDocument, bool>> filter, int? limit = null)
+        {
+            var options = new FindOptions<TDocument, TDocument>();
+            if (limit.HasValue)
+            {
+                options.Limit = limit.Value;
+            }
+            
+            return (await this.mongoDb
+                    .GetCollection<TDocument>(collectionName)
+                    .FindAsync<TDocument>(filter, options))
+                    .ToList();
         }
     }
 }

--- a/stylecop.ruleset
+++ b/stylecop.ruleset
@@ -21,7 +21,9 @@
     <Rule Id="SA1009" Action="None" /> <!-- Closing parenthesis must be spaced correctly, Does not work with valuetuples -->
     <Rule Id="SA1101" Action="None" /> <!-- Prefix local calls with this -->
     <Rule Id="SA1111" Action="None" /> <!-- Closing parenthesis must be on line of last parameter -->
+    <Rule Id="SA1515" Action="None" /> <!-- Single-line comment must be preceded by blank line -->
     <Rule Id="SA1512" Action="None" /> <!-- Single-line comments must not be followed by blank line -->
+    <Rule Id="SA1028" Action="None" /> <!-- Code must not contain trailing whitespace -->
     <Rule Id="SA1120" Action="None" /> <!-- Comments must contain text -->
   </Rules>
 </RuleSet>

--- a/test/functional/MongoDbConnectionTests.cs
+++ b/test/functional/MongoDbConnectionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
@@ -97,6 +98,47 @@ namespace RapidCore.Mongo.FunctionalTests
 
             Assert.Equal(1, actual.Count);
             Assert.Equal("two", actual[0].String);
+        }
+
+        [Fact]
+        public async Task GetAsync_ReturnsAllMatches_WhenNotGivenLimit()
+        {
+            EnsureEmptyCollection(collectionName);
+
+            Insert<Document>(collectionName, new Document { String = "one", Aux = "mememe" });
+            Insert<Document>(collectionName, new Document { String = "two", Aux = "hipster" });
+            Insert<Document>(collectionName, new Document { String = "thr", Aux = "mememe" });
+
+            var actual = await connection.GetAsync<Document>(collectionName, filter => filter.Aux == "mememe");
+
+            Assert.Equal(2, actual.Count());
+            Assert.Equal("one", actual.ElementAt(0).String);
+            Assert.Equal("thr", actual.ElementAt(1).String);
+        }
+
+        [Fact]
+        public async Task GetAsync_UsesLimit()
+        {
+            EnsureEmptyCollection(collectionName);
+
+            Insert<Document>(collectionName, new Document { String = "one", Aux = "mememe" });
+            Insert<Document>(collectionName, new Document { String = "two", Aux = "hipster" });
+            Insert<Document>(collectionName, new Document { String = "thr", Aux = "mememe" });
+
+            var actual = await connection.GetAsync<Document>(collectionName, filter => filter.Aux == "mememe", 1);
+
+            Assert.Equal(1, actual.Count());
+            Assert.Equal("one", actual.ElementAt(0).String);
+        }
+
+        [Fact]
+        public async Task GetAsync_ReturnsEmptyList_ifNoResults()
+        {
+            EnsureEmptyCollection(collectionName);
+
+            var actual = await connection.GetAsync<Document>(collectionName, filter => true, 1);
+
+            Assert.Empty(actual);
         }
 
         #region Test document


### PR DESCRIPTION
Note that this API should be considered unstable as we would prefer not loading everything into memory.

I also tried returning `IAsyncCursor` and `IEnumerable` (based `.ToEnumerable()`). This however has the annoying side-effect that you can only enumerate the result once, which sucks if you would like to get a count - perhaps if we could `IAsyncCursor` to include a count.