### PR TITLE
MongoDbConnection: InsertAsync and GetCollection

### DIFF
--- a/src/MongoDbConnection.cs
+++ b/src/MongoDbConnection.cs
@@ -33,6 +33,18 @@ namespace RapidCore.Mongo
         }
 
         /// <summary>
+        /// Async insert
+        /// </summary>
+        /// <param name="collectionName">The collection to work on</param>
+        /// <param name="doc">The document to insert</param>
+        public virtual Task InsertAsync<TDocument>(string collectionName, TDocument doc)
+        {
+            return this.mongoDb
+                .GetCollection<TDocument>(collectionName)
+                .InsertOneAsync(doc);
+        }
+
+        /// <summary>
         /// Async upsert
         /// </summary>
         /// <param name="collectionName">The collection to work on</param>

--- a/src/MongoDbConnection.cs
+++ b/src/MongoDbConnection.cs
@@ -90,5 +90,21 @@ namespace RapidCore.Mongo
                     .FindAsync<TDocument>(filter, options))
                     .ToList();
         }
+
+        /// <summary>
+        /// UNSTABLE API!!
+        /// 
+        /// Get an <see cref="IMongoCollection<T>" /> to work on. This
+        /// is to enable consumers to do advanced stuff that requires more
+        /// freedom than we can provide.
+        /// 
+        /// This method does however provide a Mocking "hook-point".
+        /// </summary>
+        /// <param name="collectionName">The name of the collection. Defaults to the name of <typeparamref name="TDocument" /></param>
+        public virtual IMongoCollection<TDocument> GetCollection<TDocument>(string collectionName = null)
+        {
+            return this.mongoDb
+                    .GetCollection<TDocument>(collectionName ?? typeof(TDocument).Name);
+        }
     }
 }

--- a/test/functional/Document.cs
+++ b/test/functional/Document.cs
@@ -1,0 +1,15 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace RapidCore.Mongo.FunctionalTests
+{
+    public class Document
+    {
+        [BsonIgnoreIfDefault]
+        public ObjectId Id { get; set; }
+
+        public string String { get; set; }
+
+        public string Aux { get; set; }
+    }
+}

--- a/test/functional/MongoDbConnectionTests.cs
+++ b/test/functional/MongoDbConnectionTests.cs
@@ -1,14 +1,12 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver;
 using Xunit;
 
 namespace RapidCore.Mongo.FunctionalTests
 {
-    public class MongoDbConnectionTests : MongoConnectedTestBase
+    public partial class MongoDbConnectionTests : MongoConnectedTestBase
     {
         private readonly MongoDbConnection connection;
         private readonly string collectionName = "documents";
@@ -140,17 +138,5 @@ namespace RapidCore.Mongo.FunctionalTests
 
             Assert.Empty(actual);
         }
-
-        #region Test document
-        private class Document
-        {
-            [BsonIgnoreIfDefault]
-            public ObjectId Id { get; set; }
-
-            public string String { get; set; }
-
-            public string Aux { get; set; }
-        }
-        #endregion
     }
 }

--- a/test/functional/MongoDbConnection_GetCollection_Tests.cs
+++ b/test/functional/MongoDbConnection_GetCollection_Tests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver;
+using Xunit;
+
+namespace RapidCore.Mongo.FunctionalTests
+{
+    public class MongoDbConnection_GetCollection_Tests : MongoConnectedTestBase
+    {
+        private readonly MongoDbConnection connection;
+
+        public MongoDbConnection_GetCollection_Tests()
+        {
+            connection = new MongoDbConnection(GetDb());
+        }
+
+        [Fact]
+        public void GetCollection_usesGivenCollectionName()
+        {
+            var actual = connection.GetCollection<Document>("kewl_stuff");
+
+            Assert.IsAssignableFrom<IMongoCollection<Document>>(actual);
+            Assert.Equal("kewl_stuff", actual.CollectionNamespace.CollectionName);
+        }
+
+        [Fact]
+        public void GetCollection_usesNameOfDocumentType_ifNotGivenACollectionName()
+        {
+            var actual = connection.GetCollection<Document>();
+
+            Assert.IsAssignableFrom<IMongoCollection<Document>>(actual);
+            Assert.Equal("Document", actual.CollectionNamespace.CollectionName);
+        }
+    }
+}

--- a/test/functional/MongoDbConnection_Insert_Tests.cs
+++ b/test/functional/MongoDbConnection_Insert_Tests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver;
+using Xunit;
+
+namespace RapidCore.Mongo.FunctionalTests
+{
+    public class MongoDbConnection_Insert_Tests : MongoConnectedTestBase
+    {
+        private readonly MongoDbConnection connection;
+        private readonly string collectionName = "documents";
+
+        public MongoDbConnection_Insert_Tests()
+        {
+            connection = new MongoDbConnection(GetDb());
+        }
+
+        [Fact]
+        public async void InsertAsync_inserts()
+        {
+            EnsureEmptyCollection(collectionName);
+
+            var doc = new Document { String = "insert" };
+            Assert.Equal(ObjectId.Empty, doc.Id);
+
+            await connection.InsertAsync<Document>(collectionName, doc);
+
+            Assert.NotEqual(ObjectId.Empty, doc.Id);
+
+            var actual = await GetDb()
+                            .GetCollection<Document>(collectionName)
+                            .Find(filter => filter.String == doc.String)
+                            .FirstOrDefaultAsync();
+
+            Assert.NotNull(actual);
+            Assert.Equal(doc.String, actual.String);
+        }
+
+        [Fact]
+        public async void InsertAsync_insertSameDocument_throws()
+        {
+            EnsureEmptyCollection(collectionName);
+
+            var doc = new Document { String = "multi" };
+
+            // first insert is ok
+            await connection.InsertAsync<Document>(collectionName, doc);
+
+            // second insert throws, as the document now has an ID
+            await Assert.ThrowsAsync<MongoWriteException>(async () => await connection.InsertAsync<Document>(collectionName, doc));
+        }
+    }
+}


### PR DESCRIPTION
Add `InsertAsync`and `GetCollection`.

`GetCollection` is kind of weird to add, but I have flagged it as "unstable api" and written why it exists (to allow advanced stuff while maintaining a mock hook-point).