### PR TITLE
Define a property for the connection string

### DIFF
--- a/src/Testing/MongoConnectedTestBase.cs
+++ b/src/Testing/MongoConnectedTestBase.cs
@@ -15,26 +15,27 @@ namespace RapidCore.Mongo.Testing
         private IMongoDatabase db;
         private bool isConnected = false;
 
+        protected string ConnectionString { get; set; } = "mongodb://localhost:27017";
+
         protected string GetDbName()
         {
             return GetType().Name;
         }
 
-        protected void Connect(string connectionString = "mongodb://localhost:27017")
+        protected void Connect()
         {
-            lowLevelClient = new MongoClient(connectionString);
-            lowLevelClient.DropDatabase(GetDbName());
-            db = lowLevelClient.GetDatabase(GetDbName());
+            if (!isConnected)
+            {
+                lowLevelClient = new MongoClient(ConnectionString);
+                lowLevelClient.DropDatabase(GetDbName());
+                db = lowLevelClient.GetDatabase(GetDbName());
+                isConnected = true;
+            }
         }
 
         protected MongoClient GetClient()
         {
-            if (!isConnected)
-            {
-                Connect();
-                isConnected = true;
-            }
-
+            Connect();
             return lowLevelClient;
         }
 


### PR DESCRIPTION
This allows consumers to override the value and actually have it used.