### PR TITLE
Add Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: csharp
+dist: trusty
+sudo: required
+mono: none
+services:
+  - mongodb
+dotnet: 1.0.4
+before_script:
+  - sleep 5
+  - mongo --eval 'db.version();'
+script:
+  - chmod +x ./Build.sh && ./Build.sh --quiet verify

--- a/Build.sh
+++ b/Build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Perform the actual build
+dotnet restore \
+&& dotnet build -c Release -f netstandard1.6 src/rapidcore.mongo.csproj \
+&& dotnet test test/unit/unittests.csproj -c Release -f netcoreapp1.1 \
+&& dotnet test test/functional/functionaltests.csproj -c Release -f netcoreapp1.1


### PR DESCRIPTION
This PR enables Travis CI builds

- Validate that things compile on Linux
- Run the functional tests as we can start a mongodb service on Travis CI