### PR TITLE
Fix EnsureIndexesShouldDropAndRetry for mongodb != 3.4

### DIFF
--- a/src/Internal/MongoCommandExceptionExtensions.cs
+++ b/src/Internal/MongoCommandExceptionExtensions.cs
@@ -9,12 +9,14 @@ namespace RapidCore.Mongo.Internal
         {
             //
             // index already exists, but with different options
+            // Check using the error code - all error codes are defined here and have been stable over time, with only new codes added:
+            // https://github.com/mongodb/mongo/blob/v3.4/src/mongo/base/error_codes.err
             //
-            if (ex.Message.Equals($"Command createIndexes failed: Index with name: {index.Name} already exists with different options."))
+            if (ex.Code == 86)
             {
                 return true;
             }
-
+            
             //
             // index already exists
             //

--- a/test/functional/functionaltests.csproj
+++ b/test/functional/functionaltests.csproj
@@ -18,4 +18,8 @@
     <ProjectReference Include="..\..\src\rapidcore.mongo.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/test/unit/unittests.csproj
+++ b/test/unit/unittests.csproj
@@ -18,4 +18,8 @@
     <ProjectReference Include="..\..\src\rapidcore.mongo.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
The mongodb team has just so slightly changed the error message when an index cannot be created due to "key spec" conflicts.

Instead of checking the error message returned, simply check the error CODE instead - this one has been stable since at least version 2.4.

Closes https://github.com/rapidcore/issues/issues/9